### PR TITLE
Remove filter rule instead of hiding

### DIFF
--- a/EnhancePoE/Model/FilterGeneration.cs
+++ b/EnhancePoE/Model/FilterGeneration.cs
@@ -74,7 +74,7 @@ namespace EnhancePoE.Model
             }
             else
             {
-                result += "Hide";
+                return "";
             }
             string nl = "\n";
             string tab = "\t";


### PR DESCRIPTION
Not sure why hiding was the default, this avoids issues like not seeing any base types you'd want entirely just because a recipe has enough.