### PR TITLE
Online filter

### DIFF
--- a/EnhancePoE/App.config
+++ b/EnhancePoE/App.config
@@ -190,6 +190,9 @@
             <setting name="LootfilterOnline" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LootfilterOnlineName" serializeAs="String">
+                <value />
+            </setting>
         </EnhancePoE.Properties.Settings>
     </userSettings>
   <runtime>

--- a/EnhancePoE/App.config
+++ b/EnhancePoE/App.config
@@ -187,6 +187,9 @@
             <setting name="Language" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="LootfilterOnline" serializeAs="String">
+                <value>False</value>
+            </setting>
         </EnhancePoE.Properties.Settings>
     </userSettings>
   <runtime>

--- a/EnhancePoE/EnhancePoE.csproj
+++ b/EnhancePoE/EnhancePoE.csproj
@@ -70,6 +70,9 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HtmlAgilityPack, Version=1.11.32.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.11.32\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
@@ -149,6 +152,7 @@
     <Compile Include="Model\StashTabList.cs" />
     <Compile Include="Model\StashTabPropsList.cs" />
     <Compile Include="Model\Storage\IFilterStorage.cs" />
+    <Compile Include="Model\Storage\OnlineFilterStorage.cs" />
     <Compile Include="Model\Utility.cs" />
     <Compile Include="Model\Win32.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/EnhancePoE/EnhancePoE.csproj
+++ b/EnhancePoE/EnhancePoE.csproj
@@ -140,12 +140,15 @@
     <Compile Include="Model\Cell.cs" />
     <Compile Include="Model\Coordinates.cs" />
     <Compile Include="Model\FilterGeneration.cs" />
+    <Compile Include="Model\Storage\FileFilterStorage.cs" />
+    <Compile Include="Model\Storage\FilterStorageFactory.cs" />
     <Compile Include="Model\ForegroundWindows.cs" />
     <Compile Include="Model\ItemSet.cs" />
     <Compile Include="Model\MouseHook.cs" />
     <Compile Include="Model\RateLimit.cs" />
     <Compile Include="Model\StashTabList.cs" />
     <Compile Include="Model\StashTabPropsList.cs" />
+    <Compile Include="Model\Storage\IFilterStorage.cs" />
     <Compile Include="Model\Utility.cs" />
     <Compile Include="Model\Win32.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/EnhancePoE/Model/Data.cs
+++ b/EnhancePoE/Model/Data.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using EnhancePoE.Model;
+using EnhancePoE.Model.Storage;
 
 
 namespace EnhancePoE
@@ -324,7 +325,7 @@ namespace EnhancePoE
             }
         }
 
-        public static void CheckActives()
+        public static async Task CheckActives()
         {
             try
             {
@@ -739,9 +740,11 @@ namespace EnhancePoE
                     //sectionList.Add(FilterGeneration.GenerateSection(true, "Amulets"));
                     //sectionList.Add(FilterGeneration.GenerateSection(true, "Belts"));
 
-                    string oldFilter = FilterGeneration.OpenLootfilter();
+                    var filterStorage = FilterStorageFactory.Create(Properties.Settings.Default);
+
+                    string oldFilter = await filterStorage.ReadLootFilterAsync();
                     string newFilter = FilterGeneration.GenerateLootFilter(oldFilter, sectionList);
-                    FilterGeneration.WriteLootfilter(newFilter);
+                    await filterStorage.WriteLootFilterAsync(newFilter);
 
 
                     List<string> sectionListInfluenced = new List<string>();
@@ -757,15 +760,15 @@ namespace EnhancePoE
                         sectionListInfluenced.Add(FilterGeneration.GenerateSection(true, "OneHandWeapons", true));
                         sectionListInfluenced.Add(FilterGeneration.GenerateSection(true, "TwoHandWeapons", true));
 
-                        string oldFilter2 = FilterGeneration.OpenLootfilter();
+                        string oldFilter2 = await filterStorage.ReadLootFilterAsync();
                         string newFilter2 = FilterGeneration.GenerateLootFilterInfluenced(oldFilter2, sectionListInfluenced);
-                        FilterGeneration.WriteLootfilter(newFilter2);
+                        await filterStorage.WriteLootFilterAsync(newFilter2);
                     }
                     else
                     {
-                        string oldFilter2 = FilterGeneration.OpenLootfilter();
+                        string oldFilter2 = await filterStorage.ReadLootFilterAsync();
                         string newFilter2 = FilterGeneration.GenerateLootFilterInfluenced(oldFilter2, sectionListInfluenced);
-                        FilterGeneration.WriteLootfilter(newFilter2);
+                        await filterStorage.WriteLootFilterAsync(newFilter2);
                     }
                 }
                 if (Properties.Settings.Default.Sound)

--- a/EnhancePoE/Model/FilterGeneration.cs
+++ b/EnhancePoE/Model/FilterGeneration.cs
@@ -11,34 +11,6 @@ namespace EnhancePoE.Model
         public static List<string> CustomStyle { get; set; } = new List<string>();
         public static List<string> CustomStyleInfluenced { get; set; } = new List<string>();
 
-        public static string OpenLootfilter()
-        {
-            string location = Properties.Settings.Default.LootfilterLocation;
-            if(location != "")
-            {
-                using(StreamReader reader = new StreamReader(location))
-                {
-                    string ret = reader.ReadToEnd();
-                    reader.Close();
-                    return ret;
-                }
-            }
-            return null;
-        }
-
-        public static void WriteLootfilter(string filter)
-        {
-            string location = Properties.Settings.Default.LootfilterLocation;
-            if(location != "" && filter != "")
-            {
-                using(StreamWriter writer = new StreamWriter(location))
-                {
-                    writer.Write(filter);
-                    writer.Close();
-                }
-            }
-        }
-
         public static void LoadCustomStyle()
         {
             CustomStyle.Clear();

--- a/EnhancePoE/Model/Storage/FileFilterStorage.cs
+++ b/EnhancePoE/Model/Storage/FileFilterStorage.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace EnhancePoE.Model.Storage
+{
+    internal class FileFilterStorage : IFilterStorage
+    {
+        private readonly string _fileLocation;
+
+        public FileFilterStorage(string fileLocation)
+        {
+            _fileLocation = fileLocation;
+        }
+
+        public async Task<string> ReadLootFilterAsync()
+        {
+            if (_fileLocation != "")
+            {
+                using (StreamReader reader = new StreamReader(_fileLocation))
+                {
+                    return await reader.ReadToEndAsync();
+                }
+            }
+            return null;
+        }
+
+        public async Task WriteLootFilterAsync(string filter)
+        {
+            if (_fileLocation != "" && filter != "")
+            {
+                using (StreamWriter writer = new StreamWriter(_fileLocation))
+                {
+                    await writer.WriteAsync(filter);
+                }
+            }
+        }
+    }
+}

--- a/EnhancePoE/Model/Storage/FilterStorageFactory.cs
+++ b/EnhancePoE/Model/Storage/FilterStorageFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace EnhancePoE.Model.Storage
+{
+    public static class FilterStorageFactory
+    {
+        public static IFilterStorage Create(string lootFilterFilePath)
+        {
+            return new FileFilterStorage(lootFilterFilePath);
+        }
+
+        internal static IFilterStorage Create(Properties.Settings settings)
+        {
+            return Create(settings.LootfilterLocation);
+        }
+    }
+}

--- a/EnhancePoE/Model/Storage/FilterStorageFactory.cs
+++ b/EnhancePoE/Model/Storage/FilterStorageFactory.cs
@@ -2,14 +2,31 @@
 {
     public static class FilterStorageFactory
     {
-        public static IFilterStorage Create(string lootFilterFilePath)
+        public static IFilterStorage Create(
+            bool settingsLootFilterOnline,
+            string lootFilterFilePath,
+            string filterName,
+            string accName,
+            string sessionId)
         {
-            return new FileFilterStorage(lootFilterFilePath);
+            if (settingsLootFilterOnline)
+            {
+                return new OnlineFilterStorage(filterName, accName, sessionId);
+            }
+            else
+            {
+                return new FileFilterStorage(lootFilterFilePath);
+            }
         }
 
         internal static IFilterStorage Create(Properties.Settings settings)
         {
-            return Create(settings.LootfilterLocation);
+            return Create(
+                settings.LootfilterOnline,
+                settings.LootfilterLocation,
+                settings.LootfilterOnlineName,
+                settings.accName,
+                settings.SessionId);
         }
     }
 }

--- a/EnhancePoE/Model/Storage/IFilterStorage.cs
+++ b/EnhancePoE/Model/Storage/IFilterStorage.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace EnhancePoE.Model.Storage
+{
+    public interface IFilterStorage
+    {
+        Task<string> ReadLootFilterAsync();
+        Task WriteLootFilterAsync(string filter);
+    }
+}

--- a/EnhancePoE/Model/Storage/OnlineFilterStorage.cs
+++ b/EnhancePoE/Model/Storage/OnlineFilterStorage.cs
@@ -1,0 +1,136 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnhancePoE.Model.Storage
+{
+    public class OnlineFilterStorage : IFilterStorage
+    {
+        private readonly string _filterName;
+        private readonly string _accName;
+        private readonly string _sessionId;
+
+        private const string FilterUrlXPathTemplate =
+            "//div[@class='item-filter' and h3/a/text()='{0}']/div[@class='item-filter-buttons']/a[@class='button-text' and text()='Edit']";
+        public static readonly Uri FiltersUrl = new Uri("https://www.pathofexile.com/account/view-profile/{0}/item-filters");
+        private string _filterUrl;
+        private Dictionary<string, string> _filterData;
+
+        internal OnlineFilterStorage(string filterName, string accName, string sessionId)
+        {
+            _filterName = filterName;
+            _accName = accName;
+            _sessionId = sessionId;
+        }
+
+        public async Task<string> ReadLootFilterAsync()
+        {
+            var filterUrl = await GetFilterUrlAsync();
+
+            if (string.IsNullOrWhiteSpace(filterUrl))
+            {
+                return null;
+            }
+
+            using (var handler = GetHandler(filterUrl))
+            using (HttpClient client = new HttpClient(handler))
+            {
+                var response = await client.GetAsync(filterUrl);
+
+                var stream = await response.Content.ReadAsStreamAsync();
+                HtmlDocument document = new HtmlDocument();
+                document.Load(stream, Encoding.UTF8);
+                _filterData = ParseToDictionary(document);
+
+                return _filterData["filter"];
+            }
+        }
+
+        public async Task WriteLootFilterAsync(string filter)
+        {
+            if (_filterData == null)
+            {
+                await ReadLootFilterAsync();
+            }
+
+            var filterUrl = await GetFilterUrlAsync();
+
+            _filterData["filter"] = filter;
+            _filterData["version"] = "g_" + DateTime.UtcNow.ToString("yyyyMMdd_hhmmss", CultureInfo.InvariantCulture);
+
+            using (var handler = GetHandler(filterUrl))
+            using (HttpClient client = new HttpClient(handler))
+            {
+                // Cannot use FormUrlEncodedContent because it has limitations on variable sizes
+                var encodedItems = _filterData.Select(i => WebUtility.UrlEncode(i.Key) + "=" + WebUtility.UrlEncode(i.Value));
+                var content = new StringContent(string.Join("&", encodedItems), null, "application/x-www-form-urlencoded");
+
+                await client.PostAsync(filterUrl, content);
+
+                _filterData = null;
+            }
+        }
+
+        private async Task<string> GetFilterUrlAsync()
+        {
+            if (_filterUrl == null)
+            {
+                string url = string.Format(FiltersUrl.ToString(), _accName);
+                using (var handler = GetHandler(url))
+                using (HttpClient client = new HttpClient(handler))
+                {
+                    var response = await client.GetAsync(url).ConfigureAwait(false);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        HtmlDocument document = new HtmlDocument();
+                        document.Load(stream, Encoding.UTF8);
+
+                        var xpath = string.Format(FilterUrlXPathTemplate, _filterName);
+                        _filterUrl = document.DocumentNode.SelectSingleNode(xpath)?.GetAttributeValue("href", null);
+
+                        if (_filterUrl != null)
+                        {
+                            _filterUrl = "https://www.pathofexile.com" + _filterUrl;
+                        }
+                    }
+                }
+            }
+
+            return _filterUrl;
+        }
+
+        private HttpClientHandler GetHandler(string url)
+        {
+            var cookieContainer = new CookieContainer();
+            cookieContainer.Add(new Uri(url), new Cookie("POESESSID", _sessionId));
+            return new HttpClientHandler { CookieContainer = cookieContainer };
+        }
+
+        private Dictionary<string, string> ParseToDictionary(HtmlDocument document)
+        {
+            Dictionary<string, string> result = new Dictionary<string, string>
+            {
+                ["filter_name"] = document.DocumentNode.SelectSingleNode("//input[@name='filter_name']").GetAttributeValue("value", ""),
+                ["realm"] = document.DocumentNode.SelectSingleNode("//select[@name='realm']/option[@selected]").GetAttributeValue("value", null),
+                ["public"] = document.DocumentNode.SelectSingleNode("//input[@id='public']").Attributes.Any(a => a.Name == "checked") ? "1" : "0",
+                ["description"] = WebUtility.HtmlDecode(document.DocumentNode.SelectSingleNode("//textarea[@name='description']").InnerText.Trim()),
+                ["version"] = "",
+                ["should_validate"] = document.DocumentNode.SelectSingleNode("//input[@id='should_validate']").Attributes.Any(a => a.Name == "checked") ? "1" : "0",
+                ["filter"] = WebUtility.HtmlDecode(document.DocumentNode.SelectSingleNode("//textarea[@name='filter']").InnerText.Trim()),
+                ["copied_from"] = document.DocumentNode.SelectSingleNode("//input[@name='copied_from']").GetAttributeValue("value", null),
+                ["hash"] = document.DocumentNode.SelectSingleNode("//input[@name='hash']").GetAttributeValue("value", null),
+                ["submit"] = "Submit"
+            };
+
+
+            return result;
+        }
+    }
+}

--- a/EnhancePoE/Properties/Settings.Designer.cs
+++ b/EnhancePoE/Properties/Settings.Designer.cs
@@ -730,5 +730,17 @@ namespace EnhancePoE.Properties {
                 this["Language"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LootfilterOnline {
+            get {
+                return ((bool)(this["LootfilterOnline"]));
+            }
+            set {
+                this["LootfilterOnline"] = value;
+            }
+        }
     }
 }

--- a/EnhancePoE/Properties/Settings.Designer.cs
+++ b/EnhancePoE/Properties/Settings.Designer.cs
@@ -742,5 +742,17 @@ namespace EnhancePoE.Properties {
                 this["LootfilterOnline"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LootfilterOnlineName {
+            get {
+                return ((string)(this["LootfilterOnlineName"]));
+            }
+            set {
+                this["LootfilterOnlineName"] = value;
+            }
+        }
     }
 }

--- a/EnhancePoE/Properties/Settings.settings
+++ b/EnhancePoE/Properties/Settings.settings
@@ -182,5 +182,8 @@
     <Setting Name="LootfilterOnline" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LootfilterOnlineName" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EnhancePoE/Properties/Settings.settings
+++ b/EnhancePoE/Properties/Settings.settings
@@ -179,5 +179,8 @@
     <Setting Name="Language" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="LootfilterOnline" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EnhancePoE/View/ChaosRecipeEnhancer.xaml.cs
+++ b/EnhancePoE/View/ChaosRecipeEnhancer.xaml.cs
@@ -378,9 +378,9 @@ namespace EnhancePoE
                     {
                         try
                         {
-                            await Task.Run(() =>
+                            await Task.Run(async () =>
                             {
-                                Data.CheckActives();
+                                await Data.CheckActives();
                                 SetOpacity();
 
                                 //ChaosRecipeEnhancer.aTimer.Enabled = true;

--- a/EnhancePoE/View/MainWindow.xaml
+++ b/EnhancePoE/View/MainWindow.xaml
@@ -878,6 +878,22 @@
 							           ToolTipService.InitialShowDelay="50"
 							           ToolTip="The path to your lootfilter. Standard path is: 'Username/Documents/My Games/Path of Exile'."
 							           Visibility="{Binding LootfilterFileDialogVisible}"/>
+							<TextBlock Grid.Column="1"
+							           Grid.Row="7"
+							           VerticalAlignment="Center"
+							           ToolTipService.InitialShowDelay="50"
+							           ToolTip="Name of filter to control. Can be found by the link. You should be signed in."
+							           Visibility="{Binding LootfilterOnlineFilterNameVisible}">
+								Filter Name (<Hyperlink 
+									             NavigateUri="https://www.pathofexile.com/account/view-profile/{0}/item-filters"
+									             RequestNavigate="Hyperlink_RequestNavigateByAccName">here</Hyperlink>):
+							</TextBlock>
+							<TextBox x:Name="LootfilterOnlineFilterName"
+							         Grid.Column="3"
+							         Grid.Row="7"
+							         Width="200"
+							         Text="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterOnlineName, Mode=TwoWay}" 
+							         Visibility="{Binding LootfilterOnlineFilterNameVisible}"/>
 							<Button Grid.Column="3"
 									Grid.Row="7"
 									x:Name="LootfilterFileDialog"

--- a/EnhancePoE/View/MainWindow.xaml
+++ b/EnhancePoE/View/MainWindow.xaml
@@ -6,6 +6,7 @@
 		xmlns:local="clr-namespace:EnhancePoE"
 		xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
 		xmlns:properties="clr-namespace:EnhancePoE.Properties"
+		xmlns:storage="clr-namespace:EnhancePoE.Model.Storage"
 		mc:Ignorable="d"
 		FontSize="14"
 		Title="Chaos Recipe Enhancer Settings"
@@ -885,7 +886,7 @@
 							           ToolTip="Name of filter to control. Can be found by the link. You should be signed in."
 							           Visibility="{Binding LootfilterOnlineFilterNameVisible}">
 								Filter Name (<Hyperlink 
-									             NavigateUri="https://www.pathofexile.com/account/view-profile/{0}/item-filters"
+									             NavigateUri="{x:Static storage:OnlineFilterStorage.FiltersUrl}"
 									             RequestNavigate="Hyperlink_RequestNavigateByAccName">here</Hyperlink>):
 							</TextBlock>
 							<TextBox x:Name="LootfilterOnlineFilterName"

--- a/EnhancePoE/View/MainWindow.xaml
+++ b/EnhancePoE/View/MainWindow.xaml
@@ -139,7 +139,7 @@
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
-								<RowDefinition Height="25"></RowDefinition>								
+								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="10"></RowDefinition>
@@ -572,7 +572,7 @@
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
-								<RowDefinition Height="25"></RowDefinition>								
+								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="10"></RowDefinition>
@@ -835,7 +835,9 @@
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
-								<RowDefinition Height="25"></RowDefinition>								
+								<RowDefinition Height="25"></RowDefinition>
+								<RowDefinition Height="5"></RowDefinition>
+								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="5"></RowDefinition>
 								<RowDefinition Height="25"></RowDefinition>
 								<RowDefinition Height="10"></RowDefinition>
@@ -859,20 +861,33 @@
 									  VerticalAlignment="Center"
 									  IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterActive, Mode=TwoWay}" />
 							<TextBlock Grid.Column="1"
-									   Grid.Row="5"
-									   VerticalAlignment="Center"
-									   Text="Lootfilter Location:"
-									   ToolTipService.InitialShowDelay="50"
-									   ToolTip="The path to your lootfilter. Standard path is: 'Username/Documents/My Games/Path of Exile'." />
+							           Grid.Row="5"
+							           VerticalAlignment="Center"
+							           Text="Online Filter:"
+							           ToolTipService.InitialShowDelay="50"
+							           ToolTip="Activates working with on-line filters." />
+							<CheckBox Grid.Column="3"
+							          Grid.Row="5"
+							          x:Name="LootfilterOnlineCheckbox"
+							          VerticalAlignment="Center"
+							          IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterOnline, Mode=TwoWay}" Checked="LootfilterOnlineCheckbox_Checked" Unchecked="LootfilterOnlineCheckbox_Checked" />
+							<TextBlock Grid.Column="1"
+							           Grid.Row="7"
+							           VerticalAlignment="Center"
+							           Text="Lootfilter Location:"
+							           ToolTipService.InitialShowDelay="50"
+							           ToolTip="The path to your lootfilter. Standard path is: 'Username/Documents/My Games/Path of Exile'."
+							           Visibility="{Binding LootfilterFileDialogVisible}"/>
 							<Button Grid.Column="3"
-									Grid.Row="5"
+									Grid.Row="7"
 									x:Name="LootfilterFileDialog"
 									Width="200"
 									Click="LootfilterFileDialog_Click"
 									ToolTipService.InitialShowDelay="50"
 									ToolTip="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterLocation, Mode=TwoWay}"
 									Content="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterLocation, Mode=TwoWay}"
-									HorizontalContentAlignment="Left">
+									HorizontalContentAlignment="Left"
+									Visibility="{Binding LootfilterFileDialogVisible}">
 								<Button.Style>
 									<Style TargetType="Button">
 										<Setter Property="Background"
@@ -888,13 +903,13 @@
 								</Button.Style>
 							</Button>
 							<TextBlock Grid.Column="1"
-									   Grid.Row="7"
+									   Grid.Row="9"
 									   VerticalAlignment="Center"
 									   Text="Show Icon on Map:"
 									   ToolTipService.InitialShowDelay="50"
 									   ToolTip="Activates icons on the minimap." />
 							<CheckBox Grid.Column="3"
-									  Grid.Row="7"
+									  Grid.Row="9"
 									  x:Name="LootfilterIconsCheckBox"
 									  VerticalAlignment="Center"
 									  IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LootfilterIcons, Mode=TwoWay}" />

--- a/EnhancePoE/View/MainWindow.xaml.cs
+++ b/EnhancePoE/View/MainWindow.xaml.cs
@@ -56,6 +56,9 @@ namespace EnhancePoE
             }
         }
 
+        public Visibility LootfilterFileDialogVisible => Properties.Settings.Default.LootfilterOnline
+            ? Visibility.Collapsed
+            : Visibility.Visible;
         //public static TabItemViewModel stashTabsModel = new TabItemViewModel();
 
 
@@ -704,6 +707,11 @@ namespace EnhancePoE
             {
                 overlay.AmountsVisibility = Visibility.Hidden;
             }
+        }
+
+        private void LootfilterOnlineCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            OnPropertyChanged(nameof(LootfilterFileDialogVisible));
         }
     }
 }

--- a/EnhancePoE/View/MainWindow.xaml.cs
+++ b/EnhancePoE/View/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Forms;
 using System.ComponentModel;
+using System.Windows.Navigation;
 using EnhancePoE.Model;
 using EnhancePoE.View;
 
@@ -59,6 +60,10 @@ namespace EnhancePoE
         public Visibility LootfilterFileDialogVisible => Properties.Settings.Default.LootfilterOnline
             ? Visibility.Collapsed
             : Visibility.Visible;
+
+        public Visibility LootfilterOnlineFilterNameVisible => Properties.Settings.Default.LootfilterOnline
+            ? Visibility.Visible
+            : Visibility.Collapsed;
         //public static TabItemViewModel stashTabsModel = new TabItemViewModel();
 
 
@@ -712,6 +717,21 @@ namespace EnhancePoE
         private void LootfilterOnlineCheckbox_Checked(object sender, RoutedEventArgs e)
         {
             OnPropertyChanged(nameof(LootfilterFileDialogVisible));
+            OnPropertyChanged(nameof(LootfilterOnlineFilterNameVisible));
+        }
+
+        private void Hyperlink_RequestNavigateByAccName(object sender, RequestNavigateEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(Properties.Settings.Default.accName))
+            {
+                const string messageBoxText = "You first need enter your account name";
+                System.Windows.MessageBox.Show(messageBoxText, "Missing Settings", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            else
+            {
+                string url = string.Format(e.Uri.ToString(), Properties.Settings.Default.accName);
+                System.Diagnostics.Process.Start(url);
+            }
         }
     }
 }

--- a/EnhancePoE/View/MainWindow.xaml.cs
+++ b/EnhancePoE/View/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using System.ComponentModel;
 using System.Windows.Navigation;
 using EnhancePoE.Model;
+using EnhancePoE.Model.Storage;
 using EnhancePoE.View;
 
 //using EnhancePoE.TabItemViewModel;
@@ -425,6 +426,8 @@ namespace EnhancePoE
             string sessId = Properties.Settings.Default.SessionId;
             string league = Properties.Settings.Default.League;
             string lootfilterLocation = Properties.Settings.Default.LootfilterLocation;
+            bool lootfilterOnline = Properties.Settings.Default.LootfilterOnline;
+            string lootfilterOnlineName = Properties.Settings.Default.LootfilterOnlineName;
             bool lootfilterActive = Properties.Settings.Default.LootfilterActive;
             string logLocation = Properties.Settings.Default.LogLocation;
             bool autoFetch = Properties.Settings.Default.AutoFetch;
@@ -446,9 +449,14 @@ namespace EnhancePoE
             }
             if (lootfilterActive)
             {
-                if(lootfilterLocation == "")
+                if(!lootfilterOnline && lootfilterLocation == "")
                 {
                     missingSettings.Add("- Lootfilter Location \n");
+                }
+
+                if (lootfilterOnline && lootfilterOnlineName == "")
+                {
+                    missingSettings.Add("- Lootfilter Name \n");
                 }
             }
             if (autoFetch)

--- a/EnhancePoE/packages.config
+++ b/EnhancePoE/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Extended.Wpf.Toolkit" version="4.0.1" targetFramework="net472" />
+  <package id="HtmlAgilityPack" version="1.11.32" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />


### PR DESCRIPTION
Path of Exile stores filters in specific file only on PC. But if playing on console or using Geforce Now there is no access to loot filter files. The only possible approach is to use online filter. I added possibility to manipulate that filters the same way as if they were files on PC version