### PR TITLE
Fix NullReferencException when pulling online filter

### DIFF
--- a/EnhancePoE/Model/Storage/OnlineFilterStorage.cs
+++ b/EnhancePoE/Model/Storage/OnlineFilterStorage.cs
@@ -117,7 +117,6 @@ namespace EnhancePoE.Model.Storage
             {
                 ["filter_name"] = document.DocumentNode.SelectSingleNode("//input[@name='filter_name']").GetAttributeValue("value", ""),
                 ["realm"] = document.DocumentNode.SelectSingleNode("//select[@name='realm']/option[@selected]").GetAttributeValue("value", null),
-                ["public"] = document.DocumentNode.SelectSingleNode("//input[@id='public']").Attributes.Any(a => a.Name == "checked") ? "1" : "0",
                 ["description"] = WebUtility.HtmlDecode(document.DocumentNode.SelectSingleNode("//textarea[@name='description']").InnerText.Trim()),
                 ["version"] = "",
                 ["should_validate"] = document.DocumentNode.SelectSingleNode("//input[@id='should_validate']").Attributes.Any(a => a.Name == "checked") ? "1" : "0",


### PR DESCRIPTION
This avoids the NullReferenceException.

While this technically works... support for online filters isn't ideal. Every time the filter needs to change it makes a request to pathofexile.com which seems like it is an unnecessary burden. I think this feature should be disabled and reimplemented in a way that only manipulates a local copy of the online filter.