### PR TITLE
Improved league selection

### DIFF
--- a/EnhancePoE/Model/ApiAdapter.cs
+++ b/EnhancePoE/Model/ApiAdapter.cs
@@ -50,6 +50,25 @@ namespace EnhancePoE
             return false;
         }
 
+        public static List<string> GetAllLeagueNames()
+        {
+            var leagueIds = new List<string>();
+
+            using (WebClient wc = new WebClient())
+            {
+                string json = wc.DownloadString("https://api.pathofexile.com/leagues?type=main&compact=1");
+                var document = JsonDocument.Parse(json);
+                var allLeagueData = document.RootElement.EnumerateArray();
+                foreach (var league in allLeagueData)
+                {
+                    string id = league.GetProperty("id").GetString();
+                    leagueIds.Add(id);
+                }
+            }
+
+            return leagueIds;
+        }
+
         private static void GenerateStashTabs()
         {
             var ret = new List<StashTab>();

--- a/EnhancePoE/View/MainWindow.xaml
+++ b/EnhancePoE/View/MainWindow.xaml
@@ -113,11 +113,12 @@
                                        Text="League:"
                                        ToolTipService.InitialShowDelay="50"
                                        ToolTip="The league you are playing in." />
-                            <TextBox x:Name="League"
-                                     Grid.Column="3"
-                                     Grid.Row="7"
-                                     Width="200"
-                                     Text="{Binding Source={x:Static properties:Settings.Default}, Path=League, Mode=TwoWay}" />
+                            <ComboBox Grid.Column="3"
+                                      Grid.Row="7"
+                                      Width="200"
+                                      VerticalContentAlignment="Center"
+                                      Name="LeagueComboBox"
+                                      SelectedValue="{Binding Source={x:Static properties:Settings.Default}, Path=League, Mode=TwoWay}" />
                         </Grid>
                         <!-- RECIPES -->
                         <Grid Grid.Column="1"

--- a/EnhancePoE/View/MainWindow.xaml.cs
+++ b/EnhancePoE/View/MainWindow.xaml.cs
@@ -76,6 +76,9 @@ namespace EnhancePoE
             // initialize stashtabs
             //DataContext = stashTabsModel;
 
+            // Populate the league dropdown
+            LeagueComboBox.ItemsSource = ApiAdapter.GetAllLeagueNames();
+
             InitializeColors();
             InitializeHotkeys();
             InitializeTray();


### PR DESCRIPTION
**Problem:** Users can enter invalid league names resulting in a bad request error
**Solution:** Only allow them to select from live leagues

- Replaced league text box with a dropdown
- Automatically populated the dropdown from the PoE API for currently running leagues