### PR TITLE
fix crash on no key with modifier

### DIFF
--- a/EnhancePoE.UI/Model/HotkeysManager.cs
+++ b/EnhancePoE.UI/Model/HotkeysManager.cs
@@ -114,22 +114,24 @@ namespace EnhancePoE.UI
             {
                 if (Keyboard.Modifiers != ModifierKeys.None)
                     foreach (var hotkey in Hotkeys)
+                        if(hotkey.Key != Key.None)
+                            if (Keyboard.Modifiers == hotkey.Modifier && Keyboard.IsKeyDown(hotkey.Key))
+                                if (hotkey.CanExecute)
+                                {
+                                    hotkey.Callback?.Invoke();
+                                    HotkeyFired?.Invoke(hotkey);
+                                }
+            }
+            else
+            {
+                foreach (var hotkey in Hotkeys)
+                    if (hotkey.Key != Key.None)
                         if (Keyboard.Modifiers == hotkey.Modifier && Keyboard.IsKeyDown(hotkey.Key))
                             if (hotkey.CanExecute)
                             {
                                 hotkey.Callback?.Invoke();
                                 HotkeyFired?.Invoke(hotkey);
                             }
-            }
-            else
-            {
-                foreach (var hotkey in Hotkeys)
-                    if (Keyboard.Modifiers == hotkey.Modifier && Keyboard.IsKeyDown(hotkey.Key))
-                        if (hotkey.CanExecute)
-                        {
-                            hotkey.Callback?.Invoke();
-                            HotkeyFired?.Invoke(hotkey);
-                        }
             }
         }
 


### PR DESCRIPTION
Only pressing a modifier `SHIFT,ALT,CTRL` made the program crash, added a check for if key equals None or not.