### PR TITLE
Removed clipboard functionality for filter reloading due to timing issues

### DIFF
--- a/ChaosRecipeEnhancer.UI/Model/ReloadItemFilter.cs
+++ b/ChaosRecipeEnhancer.UI/Model/ReloadItemFilter.cs
@@ -8,7 +8,6 @@ using System.Windows.Forms;
 using ChaosRecipeEnhancer.App.Native;
 using ChaosRecipeEnhancer.UI.Model.Utils;
 using ChaosRecipeEnhancer.UI.Properties;
-using Clipboard = System.Windows.Clipboard;
 // REF: https://stackoverflow.com/a/1635680
 using HWND = System.IntPtr;
 
@@ -62,14 +61,8 @@ namespace ChaosRecipeEnhancer.UI.Model
 
         public static void ReloadFilter()
         {
-            // Saving state of current clipboard
-            // TODO How does this work if you have non-text on your clipboard?
-            var oldClipboard = Clipboard.GetText();
-
             var chatCommand = BuildFilterReloadCommand();
             if (chatCommand is null) return;
-
-            ClipboardNative.CopyTextToClipboard(chatCommand);
 
             // Map all current window names to their associated "handle to a window" pointers (HWND)
             var openWindows = GetOpenWindows();
@@ -95,11 +88,8 @@ namespace ChaosRecipeEnhancer.UI.Model
 
             // Compose a series of commands we send to the game window (the in-game chat box, specifically)
             SendKeys.SendWait("{ENTER}");
-            SendKeys.SendWait("^(v)");
+            SendKeys.SendWait(chatCommand);
             SendKeys.SendWait("{ENTER}");
-
-            // restore clipboard
-            Clipboard.SetDataObject(oldClipboard);
         }
 
         private static string BuildFilterReloadCommand()


### PR DESCRIPTION
Removed clipboard functionality for filter reloading due to timing issues with the SendKeys.SendWait method. Due to these timing issues, the 'ctrl-v' paste may occur after the clipboard has been reset, leading to users sending the contents of their clipboard to global/local chat. For now, we simply send the string via SendKeys.SendWait instead of pasting from the clipboard.

An alternative solution could be to wait before putting the old clipboard data back into the clipboard, but depending on timing this may not be a completely safe method. There may be another alternative to SendKeys.SendWait that does not exhibit the same timing issues, however since there is potential for users to paste privileged information from their clipboard (such as passwords) to public chat channels with thousands of users, this quick solution should be sufficient for the time being. 