### PR TITLE
bugfix/set-tracker-overlay-expanding -> develop: Fixing padding issue during warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+#### 1.6.1
+
+- 
+
 #### 1.6.0.2 (Hotfix)
 
 - fixed null pointer exception thrown when completing set collection in the stash tab overlay (specifically when using the 'Set by Set' or 'All Items' highlighting modes) (Thanks to hakaisu on Discord for reporting this bug!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### 1.6.1
 
-- 
+- removed clipboard integration when sending chat commands as it was causing users to paste clipboard into chat (thanks to [drifio](https://github.com/drifio))
+- fixing misalignment of sets text in the set tracker overlay
+- fixing empty padding that would stay after filling sets (or triggering any other message) when using the horizontal versions of the set tracker overlay, it now collapses after the message clears
 
 #### 1.6.0.2 (Hotfix)
 

--- a/ChaosRecipeEnhancer.App/Properties/AssemblyInfo.cs
+++ b/ChaosRecipeEnhancer.App/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.*")]
-[assembly: AssemblyFileVersion("1.6.0.2")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/ChaosRecipeEnhancer.DataModels/Properties/AssemblyInfo.cs
+++ b/ChaosRecipeEnhancer.DataModels/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.*")]
-[assembly: AssemblyFileVersion("1.6.0.2")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/ChaosRecipeEnhancer.Installer/ChaosRecipeEnhancer.Installer.wixproj
+++ b/ChaosRecipeEnhancer.Installer/ChaosRecipeEnhancer.Installer.wixproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-        <ProductVersion>1.6.0</ProductVersion>
+        <ProductVersion>1.6.1</ProductVersion>
         <ProjectGuid>1e01e3d3-9a5b-4869-9762-2ac5c8122c25</ProjectGuid>
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>ChaosRecipeEnhancerSetup</OutputName>

--- a/ChaosRecipeEnhancer.Installer/Product.wxs
+++ b/ChaosRecipeEnhancer.Installer/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?define ProductVersion = "1.6.0.2"?>
+<?define ProductVersion = "1.6.1.0"?>
 <?define UpgradeCode = "7524ed46-e953-4ee0-a9cb-399a81b1f3ce"?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"

--- a/ChaosRecipeEnhancer.UI/Properties/AssemblyInfo.cs
+++ b/ChaosRecipeEnhancer.UI/Properties/AssemblyInfo.cs
@@ -54,5 +54,5 @@ using System.Windows;
 // and user will have to input that information again. Be mindful of that when creating new releases. Try to limit how
 // many times your doing that.
 
-[assembly: AssemblyVersion("1.6.0.2")]
-[assembly: AssemblyFileVersion("1.6.0.2")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/MinifiedDisplay.xaml
+++ b/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/MinifiedDisplay.xaml
@@ -14,20 +14,20 @@
 
         <Grid.ColumnDefinitions>
 
-            <ColumnDefinition Width="3" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="auto" />
-            <ColumnDefinition Width="3" />
+            <ColumnDefinition Width="3" />      <!-- Column 0 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 1 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 2 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 3 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 4 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 5 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 6 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 7 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 8 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 9 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 10 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 11 -->
+            <ColumnDefinition Width="auto" />   <!-- Column 12 -->
+            <ColumnDefinition Width="3" />      <!-- Column 13 -->
 
         </Grid.ColumnDefinitions>
 
@@ -497,12 +497,12 @@
             x:Name="OverlayProgressBar" />
 
         <Border
-            Grid.Column="3"
-            Grid.ColumnSpan="9"
             Grid.Row="0"
+            Grid.Column="0"
+            Grid.ColumnSpan="14"
             CornerRadius="5"
             Background="White"
-            Margin="0,10,0,3"
+            Margin="8,8,8,3"
             Visibility="{Binding WarningMessageVisibility}">
 
             <TextBlock

--- a/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/MinifiedDisplay.xaml.cs
+++ b/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/MinifiedDisplay.xaml.cs
@@ -9,6 +9,14 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SetTrackerOverlayDisplays
     /// </summary>
     public partial class MinifiedDisplay
     {
+        #region Fields
+
+        private readonly ILogger _logger;
+        private readonly SetTrackerOverlayView _setTrackerOverlay;
+        private readonly SettingsView _settingsView;
+
+        #endregion
+
         #region Constructors
 
         public MinifiedDisplay(SettingsView settingsView, SetTrackerOverlayView setTrackerOverlay)
@@ -22,14 +30,6 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SetTrackerOverlayDisplays
 
             _logger.Debug("MinifiedDisplay  constructed successfully");
         }
-
-        #endregion
-
-        #region Fields
-
-        private readonly ILogger _logger;
-        private readonly SetTrackerOverlayView _setTrackerOverlay;
-        private readonly SettingsView _settingsView;
 
         #endregion
 

--- a/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/OnlyButtonsDisplay.xaml
+++ b/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/OnlyButtonsDisplay.xaml
@@ -129,12 +129,12 @@
             x:Name="OverlayProgressBar" />
 
         <Border
-            Grid.Column="1"
-            Grid.ColumnSpan="4"
             Grid.Row="0"
+            Grid.Column="0"
+            Grid.ColumnSpan="6"
             CornerRadius="5"
             Background="White"
-            Margin="0,3,0,3"
+            Margin="8,8,8,3"
             Visibility="{Binding WarningMessageVisibility}">
 
             <TextBlock

--- a/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/StandardDisplay.xaml
+++ b/ChaosRecipeEnhancer.UI/UserControls/SetTrackerOverlayDisplays/StandardDisplay.xaml
@@ -449,7 +449,7 @@
             Width="50"
             Columns="1"
             Rows="2"
-            Margin="5,0"
+            Margin="5 10 5 0"
             Background="White">
 
             <TextBlock
@@ -480,12 +480,12 @@
             x:Name="OverlayProgressBar" />
 
         <Border
-            Grid.Column="4"
-            Grid.ColumnSpan="6"
             Grid.Row="0"
+            Grid.Column="0"
+            Grid.ColumnSpan="14"
             CornerRadius="5"
             Background="White"
-            Margin="0,0,0,4"
+            Margin="8,8,8,4"
             Visibility="{Binding WarningMessageVisibility}">
 
             <TextBlock

--- a/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml
+++ b/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml
@@ -23,25 +23,25 @@
 
         <Grid.RowDefinitions>
 
-            <RowDefinition Height="10" />   <!-- Row 1 -->
-            <RowDefinition Height="30" />   <!-- Row 2 -->
-            <RowDefinition Height="5" />    <!-- Row 3 -->
-            <RowDefinition Height="25" />   <!-- Row 4 -->
-            <RowDefinition Height="5" />    <!-- Row 5 -->
-            <RowDefinition Height="25" />   <!-- Row 6 -->
-            <RowDefinition Height="5" />    <!-- Row 7 -->
-            <RowDefinition Height="25" />   <!-- Row 8 -->
-            <RowDefinition Height="5" />    <!-- Row 9 -->
-            <RowDefinition Height="25" />   <!-- Row 10 -->
-            <RowDefinition Height="5" />    <!-- Row 11 -->
-            <RowDefinition Height="25" />   <!-- Row 12 -->
-            <RowDefinition Height="5" />    <!-- Row 13 -->
-            <RowDefinition Height="25" />   <!-- Row 14 -->
-            <RowDefinition Height="5" />    <!-- Row 15 -->
-            <RowDefinition Height="25" />   <!-- Row 16 -->
-            <RowDefinition Height="5" />    <!-- Row 17 -->
-            <RowDefinition Height="25" />   <!-- Row 18 -->
-            <RowDefinition Height="5" />    <!-- Row 19 -->
+            <RowDefinition Height="10" />   <!-- Row 0 -->
+            <RowDefinition Height="30" />   <!-- Row 1 -->
+            <RowDefinition Height="5" />    <!-- Row 2 -->
+            <RowDefinition Height="25" />   <!-- Row 3 -->
+            <RowDefinition Height="5" />    <!-- Row 4 -->
+            <RowDefinition Height="25" />   <!-- Row 5 -->
+            <RowDefinition Height="5" />    <!-- Row 6 -->
+            <RowDefinition Height="25" />   <!-- Row 7 -->
+            <RowDefinition Height="5" />    <!-- Row 8 -->
+            <RowDefinition Height="25" />   <!-- Row 9 -->
+            <RowDefinition Height="5" />    <!-- Row 10 -->
+            <RowDefinition Height="25" />   <!-- Row 11 -->
+            <RowDefinition Height="5" />    <!-- Row 12 -->
+            <RowDefinition Height="Auto" />   <!-- Row 13 -->
+            <RowDefinition Height="5" />    <!-- Row 14 -->
+            <RowDefinition Height="25" />   <!-- Row 15 -->
+            <RowDefinition Height="5" />    <!-- Row 16 -->
+            <RowDefinition Height="25" />   <!-- Row 17 -->
+            <RowDefinition Height="5" />    <!-- Row 18 -->
 
         </Grid.RowDefinitions>
 
@@ -187,7 +187,7 @@
             Grid.Row="13"
             VerticalAlignment="Center"
             Text="PoE Client.txt File Location:"
-            ToolTipService.InitialShowDelay="50"
+            Visibility="{Binding FetchOnNewMapEnabled}"
             ToolTip="The standard path is: `C:/Programs/Grinding Gear Games/Path of Exile/logs/Client.txt`; it will be different for steam users." />
 
         <Button
@@ -196,7 +196,7 @@
             Grid.Row="13"
             Width="200"
             Click="LogLocationDialog_Click"
-            ToolTipService.InitialShowDelay="50"
+            Visibility="{Binding FetchOnNewMapEnabled}"
             ToolTip="{Binding Source={x:Static properties:Settings.Default}, Path=PathOfExileClientLogLocation, Mode=TwoWay}"
             Content="{Binding Source={x:Static properties:Settings.Default}, Path=PathOfExileClientLogLocation, Mode=TwoWay}"
             HorizontalContentAlignment="Left">
@@ -236,7 +236,6 @@
             Grid.Row="15"
             VerticalAlignment="Center"
             Text="Language:"
-            ToolTipService.InitialShowDelay="50"
             ToolTip="Fetch on new Map only works in the correct language. Set it to the same as your PoE client." />
 
         <ComboBox
@@ -263,7 +262,6 @@
             Grid.Row="17"
             VerticalAlignment="Center"
             Text="Close to Tray:"
-            ToolTipService.InitialShowDelay="50"
             ToolTip="Minimizes to Tray when closing the application." />
 
         <CheckBox
@@ -279,7 +277,6 @@
         <!--            Grid.Row="17" -->
         <!--            VerticalAlignment="Center" -->
         <!--            Text="Debug Mode:" -->
-        <!--            ToolTipService.InitialShowDelay="50" -->
         <!--            ToolTip="Enables logging to a file that you can give to the developers so they can better resolve your issue." /> -->
 
         <!-- <CheckBox x:Name="DebugMode" -->

--- a/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml.cs
+++ b/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml.cs
@@ -13,12 +13,14 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SettingsForms.GeneralForms
         private Visibility _tabIndicesVisible = Visibility.Visible;
         private Visibility _tabNamePrefixVisible = Visibility.Hidden;
         private Visibility _tabNameSuffixVisible = Visibility.Hidden;
-
+        private Visibility _fetchOnNewMapEnabled = Visibility.Collapsed;
+        
         public GeneralForm()
         {
             DataContext = this;
             InitializeComponent();
             LoadStashQueryModeVisibility();
+            LoadFetchOnNewMapEnabled();
         }
 
         public Visibility TabIndicesVisible
@@ -59,6 +61,19 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SettingsForms.GeneralForms
                 }
             }
         }
+        
+        public Visibility FetchOnNewMapEnabled
+        {
+            get => _fetchOnNewMapEnabled;
+            set
+            {
+                if (_fetchOnNewMapEnabled != value)
+                {
+                    _fetchOnNewMapEnabled = value;
+                    OnPropertyChanged("FetchOnNewMapEnabled");
+                }
+            }
+        }
 
         private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
@@ -71,10 +86,13 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SettingsForms.GeneralForms
 
         private void AutoFetchCheckBox_Checked(object sender, RoutedEventArgs e)
         {
+            LoadFetchOnNewMapEnabled();
         }
 
         private void AutoFetchCheckBox_Unchecked(object sender, RoutedEventArgs e)
         {
+            LoadFetchOnNewMapEnabled();
+
             if (LogWatcher.WorkerThread != null && LogWatcher.WorkerThread.IsAlive) LogWatcher.WorkerThread.Abort();
         }
 
@@ -121,6 +139,13 @@ namespace ChaosRecipeEnhancer.UI.UserControls.SettingsForms.GeneralForms
                     TabNameSuffixVisible = Visibility.Visible;
                     break;
             }
+        }
+
+        private void LoadFetchOnNewMapEnabled()
+        {
+            FetchOnNewMapEnabled = Settings.Default.AutoFetchOnRezoneEnabled 
+                ? Visibility.Visible 
+                : Visibility.Collapsed;
         }
 
         #region INotifyPropertyChanged implementation

--- a/ChaosRecipeEnhancer.UI/View/SetTrackerOverlayView.xaml.cs
+++ b/ChaosRecipeEnhancer.UI/View/SetTrackerOverlayView.xaml.cs
@@ -17,23 +17,6 @@ namespace ChaosRecipeEnhancer.UI.View
     /// </summary>
     public partial class SetTrackerOverlayView : INotifyPropertyChanged
     {
-        #region Constructors
-
-        public SetTrackerOverlayView()
-        {
-            _logger = Log.ForContext<SetTrackerOverlayView>();
-            _logger.Debug("Constructing ChaosRecipeEnhancer");
-
-            InitializeComponent();
-
-            DataContext = this;
-            FullSetsText = "0";
-
-            _logger.Debug("ChaosRecipeEnhancer constructed successfully");
-        }
-
-        #endregion
-
         #region Fields
 
         private readonly ILogger _logger;
@@ -83,6 +66,21 @@ namespace ChaosRecipeEnhancer.UI.View
         private static bool CalculationActive { get; set; }
 
         private static LogWatcher Watcher { get; set; }
+
+        #endregion
+        
+        #region Constructors
+
+        public SetTrackerOverlayView()
+        {
+            _logger = Log.ForContext<SetTrackerOverlayView>();
+            _logger.Debug("Constructing ChaosRecipeEnhancer");
+
+            DataContext = this;
+            InitializeComponent();
+            
+            _logger.Debug("ChaosRecipeEnhancer constructed successfully");
+        }
 
         #endregion
 
@@ -390,18 +388,18 @@ namespace ChaosRecipeEnhancer.UI.View
         {
             setTrackerOverlayView.WarningMessage = "";
             setTrackerOverlayView.ShadowOpacity = 0;
-            setTrackerOverlayView.WarningMessageVisibility = Visibility.Hidden;
+            setTrackerOverlayView.WarningMessageVisibility = Visibility.Collapsed;
         }
 
         private async void FetchData()
         {
             if (FetchingActive) return;
 
-            if (!Settings.Default.ChaosRecipeTrackingEnabled && !Settings.Default.RegalRecipeTrackingEnabled &&
+            if (!Settings.Default.ChaosRecipeTrackingEnabled &&
+                !Settings.Default.RegalRecipeTrackingEnabled &&
                 !Settings.Default.ExaltedShardRecipeTrackingEnabled)
             {
-                MessageBox.Show("No recipes are enabled. Please pick a recipe.", "No Recipes", MessageBoxButton.OK,
-                    MessageBoxImage.Error);
+                MessageBox.Show("No recipes are enabled. Please pick a recipe.", "No Recipes", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -504,11 +502,6 @@ namespace ChaosRecipeEnhancer.UI.View
                     MessageBox.Show("Missing Stash Query Settings!" + Environment.NewLine +
                                     "Please set stash tab suffix.");
                     return;
-
-                // TODO: [Refactor] Query by folder name stuff (doesn't work; not supported by API)
-                // case 3 when Settings.Default.StashFolderName == "":
-                //     MessageBox.Show("Missing Stash Query Settings!" + Environment.NewLine + "Please set stash tab folder name.");
-                //     return;
             }
 
             if (CalculationActive)
@@ -542,45 +535,37 @@ namespace ChaosRecipeEnhancer.UI.View
 
             Dispatcher.Invoke(() =>
             {
-                if (!Data.ActiveItems.HelmetActive)
-                    HelmetOpacity = DeactivatedOpacity;
-                else
-                    HelmetOpacity = ActivatedOpacity;
+                HelmetOpacity = !Data.ActiveItems.HelmetActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.GlovesActive)
-                    GlovesOpacity = DeactivatedOpacity;
-                else
-                    GlovesOpacity = ActivatedOpacity;
+                GlovesOpacity = !Data.ActiveItems.GlovesActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.BootsActive)
-                    BootsOpacity = DeactivatedOpacity;
-                else
-                    BootsOpacity = ActivatedOpacity;
+                BootsOpacity = !Data.ActiveItems.BootsActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.WeaponActive)
-                    WeaponsOpacity = DeactivatedOpacity;
-                else
-                    WeaponsOpacity = ActivatedOpacity;
+                WeaponsOpacity = !Data.ActiveItems.WeaponActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.ChestActive)
-                    ChestsOpacity = DeactivatedOpacity;
-                else
-                    ChestsOpacity = ActivatedOpacity;
+                ChestsOpacity = !Data.ActiveItems.ChestActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.RingActive)
-                    RingsOpacity = DeactivatedOpacity;
-                else
-                    RingsOpacity = ActivatedOpacity;
+                RingsOpacity = !Data.ActiveItems.RingActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.AmuletActive)
-                    AmuletsOpacity = DeactivatedOpacity;
-                else
-                    AmuletsOpacity = ActivatedOpacity;
+                AmuletsOpacity = !Data.ActiveItems.AmuletActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
 
-                if (!Data.ActiveItems.BeltActive)
-                    BeltsOpacity = DeactivatedOpacity;
-                else
-                    BeltsOpacity = ActivatedOpacity;
+                BeltsOpacity = !Data.ActiveItems.BeltActive 
+                    ? DeactivatedOpacity 
+                    : ActivatedOpacity;
             });
         }
 

--- a/ChaosRecipeEnhancer.UI/View/SettingsView.xaml.cs
+++ b/ChaosRecipeEnhancer.UI/View/SettingsView.xaml.cs
@@ -60,7 +60,7 @@ namespace ChaosRecipeEnhancer.UI.View
         private readonly StashTabOverlayView _stashTabOverlayView;
 
         // This version # should match up with the format for Assembly version # (3 dots, 4 digits), or else you'll get spammed for AutoUpdates
-        private const string AppVersion = "1.6.0.2";
+        private const string AppVersion = "1.6.1.0";
         
         private readonly NotifyIcon _notifyIcon = new NotifyIcon();
 


### PR DESCRIPTION
- fixing misalignment of sets text in the set tracker overlay
- fixing empty padding that would stay after filling sets (or triggering any other message) when using the horizontal versions of the set tracker overlay, it now collapses after the message clears