### PR TITLE
Feature/check for updates link to latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 #### 1.7.1 (WIP)
 
-- removing (broken) auto-update feature from project
-- various code improvements under the hood
-- adding Environment based NewLine (thanks to [yenbounger](https://github.com/yenbounger) for your PR)
-- updating README
+- removing broken auto-update feature from project (the button in the navigation menu now links to our [latest release page on Github](https://github.com/ChaosRecipeEnhancer/EnhancePoEApp/releases))
+- adding Environment based NewLine (thanks to [yenbounger](https://github.com/yenbounger) for your PR) that resolves issue when modifying filters after applying our filter automated filter modification
+- continued code improvements under the hood 
 
 #### 1.7.0
 


### PR DESCRIPTION
- removing broken auto-update feature from project (the button in the navigation menu now links to our [latest release page on Github](https://github.com/ChaosRecipeEnhancer/EnhancePoEApp/releases))
