### PR TITLE
Develop -> Main: v3.24.3001 Release Cont.

### DIFF
--- a/src/App/ChaosRecipeEnhancer.UI/Models/EmptySlots.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Models/EmptySlots.cs
@@ -22,7 +22,6 @@ public static class EmptySlots
                 GameTerminology.Amulets,
                 GameTerminology.Rings, // have to double up on rings
                 GameTerminology.Rings
-
             ];
 
             // Return a copy to ensure that the original is not mutable

--- a/src/App/ChaosRecipeEnhancer.UI/Services/LogWatcherManager.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Services/LogWatcherManager.cs
@@ -13,8 +13,8 @@ public class LogWatcherManager
     private static bool AutoFetchAllowed { get; set; } = true;
 
     // this should match the cooldown we apply in the set tracker view model
-    /// <see cref="SetTrackerOverlayViewModel.FetchCooldown"/>
-    private const int AutoFetchCooldown = 15;
+    /// <see cref="SetTrackerOverlayViewModel.FetchCooldownSeconds"/>
+    private const int AutoFetchCooldownSeconds = 15;
     private static string LastZone { get; set; } = "";
     private static string NewZone { get; set; } = "";
 
@@ -89,9 +89,9 @@ public class LogWatcherManager
                 // Note: No need to dispatch this back to the UI thread
                 // as we are already on the UI thread (this will differ
                 // from our other async cooldown methods)
-                await Task.Factory.StartNew(() => Thread.Sleep(AutoFetchCooldown * 1000));
+                await Task.Factory.StartNew(() => Thread.Sleep(AutoFetchCooldownSeconds * 1000));
 
-                // this will re-enable the fetch button after our AutoFetchCooldown
+                // this will re-enable the fetch button after our AutoFetchCooldownSeconds
                 setTrackerOverlay.OverrideFetchButtonEnabled();
                 AutoFetchAllowed = true;
             }

--- a/src/App/ChaosRecipeEnhancer.UI/Windows/SetTrackerOverlayViewModel.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Windows/SetTrackerOverlayViewModel.cs
@@ -30,8 +30,8 @@ public sealed class SetTrackerOverlayViewModel : ViewModelBase
     private const string SetsFullText = "Sets full!";
 
     // this should match the cooldown we apply in the log watcher manager
-    /// <see cref="LogWatcherManager.AutoFetchCooldown"/>
-    private const int FetchCooldown = 15;
+    /// <see cref="LogWatcherManager.AutoFetchCooldownSeconds"/>
+    private const int FetchCooldownSeconds = 15;
 
     private bool _fetchButtonEnabled = true;
     private bool _stashButtonTooltipEnabled = false;
@@ -291,7 +291,7 @@ public sealed class SetTrackerOverlayViewModel : ViewModelBase
                     // enforce cooldown on fetch button to reduce chances of rate limiting
                     await Dispatcher.CurrentDispatcher.InvokeAsync(async () =>
                     {
-                        await Task.Factory.StartNew(() => Thread.Sleep(FetchCooldown));
+                        await Task.Factory.StartNew(() => Thread.Sleep(FetchCooldownSeconds * 1000));
                         FetchButtonEnabled = true;
                     });
                 }
@@ -365,7 +365,7 @@ public sealed class SetTrackerOverlayViewModel : ViewModelBase
                     // enforce cooldown on fetch button to reduce chances of rate limiting
                     await Dispatcher.CurrentDispatcher.InvokeAsync(async () =>
                     {
-                        await Task.Factory.StartNew(() => Thread.Sleep(FetchCooldown * 1000));
+                        await Task.Factory.StartNew(() => Thread.Sleep(FetchCooldownSeconds * 1000));
                         FetchButtonEnabled = true;
                     });
                 }


### PR DESCRIPTION
- sleep for FetchCooldownSeconds was not calculated into milliseconds
- renaming cooldown vars for clarity (specifying units)