### PR TITLE
Reset Tabs on League Switch

### DIFF
--- a/src/App/ChaosRecipeEnhancer.UI.Tests/UserControls/SettingsForms/GeneralForms/GeneralFormViewModelTests.cs
+++ b/src/App/ChaosRecipeEnhancer.UI.Tests/UserControls/SettingsForms/GeneralForms/GeneralFormViewModelTests.cs
@@ -1,0 +1,28 @@
+using ChaosRecipeEnhancer.UI.Models.UserSettings;
+using ChaosRecipeEnhancer.UI.UserControls.SettingsForms.GeneralForms;
+
+namespace ChaosRecipeEnhancer.UI.Tests.UserControls.SettingsForms.GeneralForms;
+
+public class GeneralFormViewModelTests
+{
+    private readonly GeneralFormViewModel _sut;
+
+    public GeneralFormViewModelTests()
+    {
+        _sut = new GeneralFormViewModel(null, new UserSettings());
+    }
+
+    [Fact]
+    public void OnLeagueChange_WhenLeagueIsChanged_SelectedStashTabIndexShouldClear()
+    {
+        // Arrange
+        _sut.StashTabIndices = new HashSet<string> { "1", "2", "3" };
+        _sut.SelectedLeagueName = "Some Old League";
+        
+        // Act
+        _sut.SelectedLeagueName = "Some New League";
+        
+        // Assert
+        _sut.StashTabIndices.Should().BeEmpty();
+    }
+}

--- a/src/App/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml
+++ b/src/App/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralForm.xaml
@@ -84,7 +84,7 @@
                 Margin="0 0 5 0"
                 VerticalContentAlignment="Center"
                 ItemsSource="{Binding LeagueList, Mode=OneWay}"
-                SelectedItem="{Binding LeagueName, Mode=OneWay}"
+                SelectedItem="{Binding SelectedLeagueName, Mode=OneWay}"
                 SelectionChanged="LeagueComboBox_SelectionChanged"
                 IsEnabled="{Binding LeagueDropDownEnabled, Mode=OneWay}"
                 Visibility="{Binding LeagueDropDownEnabled, Converter={StaticResource BoolVisibilityConverter}}"
@@ -100,7 +100,7 @@
                 Width="160"
                 Margin="0 0 5 0"
                 VerticalContentAlignment="Center"
-                Text="{Binding LeagueName, Mode=OneWay}"
+                Text="{Binding SelectedLeagueName, Mode=OneWay}"
                 IsEnabled="False"
                 Visibility="{Binding LeagueDropDownEnabled, Converter={StaticResource InvertedBoolVisibilityConverter}}" />
 
@@ -274,7 +274,7 @@
                 <Button.IsEnabled>
                     <MultiBinding Converter="{StaticResource FetchButtonEnabledConverter}">
                         <Binding Path="StashTabButtonEnabled"/>
-                        <Binding Path="LeagueName"/>
+                        <Binding Path="SelectedLeagueName"/>
                     </MultiBinding>
                 </Button.IsEnabled>
 
@@ -413,7 +413,7 @@
                 <Button.IsEnabled>
                     <MultiBinding Converter="{StaticResource FetchButtonEnabledConverter}">
                         <Binding Path="StashTabButtonEnabled"/>
-                        <Binding Path="LeagueName"/>
+                        <Binding Path="SelectedLeagueName"/>
                     </MultiBinding>
                 </Button.IsEnabled>
 

--- a/src/App/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralFormViewModel.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/UserControls/SettingsForms/GeneralForms/GeneralFormViewModel.cs
@@ -118,7 +118,7 @@ public class GeneralFormViewModel : CreViewModelBase
 
     #region User Settings Properties
 
-    public string LeagueName
+    public string SelectedLeagueName
     {
         get => _userSettings.LeagueName;
         set => _ = UpdateLeagueNameAsync(value);
@@ -228,17 +228,17 @@ public class GeneralFormViewModel : CreViewModelBase
     private void InitializeDataFromUserSettings()
     {
         Log.Information("GeneralFormViewModel - Initializing data from user settings...");
-        Log.Information("Current LeagueName Property: {LeagueName}", LeagueName);
+        Log.Information("Current LeagueName Property: {LeagueName}", SelectedLeagueName);
 
         // Set LeagueName from user settings if it's valid
         if (!string.IsNullOrWhiteSpace(_userSettings.LeagueName))
         {
-            LeagueName = _userSettings.LeagueName;
+            SelectedLeagueName = _userSettings.LeagueName;
 
             // Force a refresh of the leagues list property for UI updates
-            OnPropertyChanged(nameof(LeagueName));
+            OnPropertyChanged(nameof(SelectedLeagueName));
 
-            Log.Information("Post Change LeagueName Property: {LeagueName}", LeagueName);
+            Log.Information("Post Change LeagueName Property: {LeagueName}", SelectedLeagueName);
         }
     }
 
@@ -337,6 +337,7 @@ public class GeneralFormViewModel : CreViewModelBase
         if (_userSettings.LeagueName != leagueName)
         {
             _userSettings.LeagueName = leagueName;
+            StashTabIndices = [];
 
             SetUIEnabledState(false);
 
@@ -351,7 +352,7 @@ public class GeneralFormViewModel : CreViewModelBase
                 await LoadStashTabsAsync();
             }
 
-            OnPropertyChanged(nameof(LeagueName));
+            OnPropertyChanged(nameof(SelectedLeagueName));
 
             if (StashTabDropDownEnabled)
             {
@@ -371,7 +372,7 @@ public class GeneralFormViewModel : CreViewModelBase
             _userSettings.CustomLeagueEnabled = isPrivateLeague;
 
             // reset the selected league name
-            LeagueName = string.Empty;
+            SelectedLeagueName = string.Empty;
 
             SetUIEnabledState(false);
 
@@ -449,7 +450,7 @@ public class GeneralFormViewModel : CreViewModelBase
     public async Task LoadStashTabsAsync(bool isFirstLoad = false)
     {
 
-        if (string.IsNullOrWhiteSpace(LeagueName))
+        if (string.IsNullOrWhiteSpace(SelectedLeagueName))
         {
             Log.Information("GeneralFormViewModel - League name not defined; cannot fetch Stash Tabs. Skipping fetch.");
             return;
@@ -684,13 +685,13 @@ public class GeneralFormViewModel : CreViewModelBase
 
         if (selectedItem == null)
         {
-            LeagueName = _userSettings.LeagueName;
+            SelectedLeagueName = _userSettings.LeagueName;
             return;
         }
 
         if (string.IsNullOrWhiteSpace(selectedItem.ToString())) return;
 
-        LeagueName = selectedItem.ToString();
+        SelectedLeagueName = selectedItem.ToString();
         LeagueDropDownEnabled = false;
     }
 


### PR DESCRIPTION
GeneralFormViewModel.cs line 340 is the only change enabling this, clearing the property which also clears user settings.
I have also updated the 'LeagueName' variable to 'SelectedLeagueName' - found it a little confusing working through but of course happy to revert if you disagree :) 

Confirmed functionality via unit test & manual testing