### PR TITLE
Bugfix: Incorrectly Selected Client.Txt

### DIFF
--- a/src/App/ChaosRecipeEnhancer.UI/Configuration/ExceptionHandlingConfiguration.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Configuration/ExceptionHandlingConfiguration.cs
@@ -34,34 +34,37 @@ public static class ExceptionHandlingConfiguration
 
     private static void ShowUnhandledException(Exception e, string unhandledExceptionType)
     {
-        var currentCulture = Thread.CurrentThread.CurrentUICulture;
-        try
+        Application.Current.Dispatcher.Invoke(() =>
         {
-            // Set the current thread's UI culture to English
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+            var currentCulture = Thread.CurrentThread.CurrentUICulture;
+            try
+            {
+                // Set the current thread's UI culture to English
+                Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
 
-            var limitedExceptionMessage = string.Join(
-                Environment.NewLine,
-                // split the exception message into lines and take the first 30 lines
-                e.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None).Take(5)
-            );
+                var limitedExceptionMessage = string.Join(
+                    Environment.NewLine,
+                    // split the exception message into lines and take the first 30 lines
+                    e.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None).Take(5)
+                );
 
-            var messageBoxTitle = $"Error: Unhandled Exception - {unhandledExceptionType}";
-            var messageBoxMessage =
-                $"The following exception occurred: {unhandledExceptionType}" +
-                $"{limitedExceptionMessage}";
+                var messageBoxTitle = $"Error: Unhandled Exception - {unhandledExceptionType}";
+                var messageBoxMessage =
+                    $"The following exception occurred: {unhandledExceptionType}" +
+                    $"{limitedExceptionMessage}";
 
-            var dialog = new ErrorWindow(
-                messageBoxTitle,
-                messageBoxMessage
-            );
+                var dialog = new ErrorWindow(
+                    messageBoxTitle,
+                    messageBoxMessage
+                );
 
-            dialog.ShowDialog();
-        }
-        finally
-        {
-            // Restore the original UI culture
-            Thread.CurrentThread.CurrentUICulture = currentCulture;
-        }
+                dialog.ShowDialog();
+            }
+            finally
+            {
+                // Restore the original UI culture
+                Thread.CurrentThread.CurrentUICulture = currentCulture;
+            }
+        });
     }
 }


### PR DESCRIPTION
Starting the overlay when auto-fetch setting is incorrectly set (e.g. standalone poe when you have a steam installation) would throw an exception in LogWatcherManager.cs. This was on a background thread, and not handled by the global exception handler, and would not throw on the main thread until the thread was GCed. This could cause the error to appear at random times, rather than when it actually hit (logwatchermanager being started from overlay opening)

Compounding this the Error window handler was encountering a "This was compounded by a "The calling thread must be STA, because many UI components require this." exception when spawning the error window - meaning the application would just crash silently, rather than with an error window.

I'm not 100% happy with implementation of showing an error in the constructor, and only initialising without an error, preferably we would show the error when the client.txt location is selected. I couldnt find a nice way to bubble the exception from the worker thread so anything failing would show instantly rather than post GC either.

Gimme an @ on discord if you wanna chat about any of this - prose is not my forte so may not have explained too well!

