### PR TITLE
Fix: Stash tab overlay DPI scaling and previously saved position

### DIFF
--- a/src/App/ChaosRecipeEnhancer.UI/App.config
+++ b/src/App/ChaosRecipeEnhancer.UI/App.config
@@ -101,12 +101,6 @@
             <setting name="SetTrackerOverlayLeftPosition" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="StashTabOverlayTopPosition" serializeAs="String">
-                <value>74</value>
-            </setting>
-            <setting name="StashTabOverlayLeftPosition" serializeAs="String">
-                <value>12</value>
-            </setting>
             <setting name="StashTabOverlayHeight" serializeAs="String">
                 <value>690</value>
             </setting>
@@ -589,6 +583,18 @@
             </setting>
             <setting name="SetTrackerOverlayWindowScale" serializeAs="String">
                 <value>1</value>
+            </setting>
+            <setting name="StashTabOverlayTopPosition" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="StashTabOverlayLeftPosition" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="StashTabOverlaySessionScreen" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="StashTabOverlayModified" serializeAs="String">
+                <value>False</value>
             </setting>
         </ChaosRecipeEnhancer.UI.Properties.Settings>
     </userSettings>

--- a/src/App/ChaosRecipeEnhancer.UI/ChaosRecipeEnhancer.UI.csproj
+++ b/src/App/ChaosRecipeEnhancer.UI/ChaosRecipeEnhancer.UI.csproj
@@ -36,6 +36,7 @@
 		<ApplicationIcon>Assets\Icons\CREIcon.ico</ApplicationIcon>
 		<PackageIcon>CREIcon.ico</PackageIcon>
 		<StartupObject>ChaosRecipeEnhancer.UI.App</StartupObject>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <NoWarn>1701;1702;CA1416</NoWarn>

--- a/src/App/ChaosRecipeEnhancer.UI/Models/UserSettings/IUserSettings.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Models/UserSettings/IUserSettings.cs
@@ -80,6 +80,8 @@ public interface IUserSettings
     double StashTabOverlayLeftPosition { get; set; }
     double StashTabOverlayHeight { get; set; }
     double StashTabOverlayWidth { get; set; }
+    bool StashTabOverlayModified { get; set; }
+    int StashTabOverlaySessionScreen { get; set; }
     string StashTabOverlayTabDefaultBackgroundColor { get; set; }
     double StashTabOverlayTabGroupBottomMargin { get; set; }
     float StashTabOverlayTabOpacity { get; set; }

--- a/src/App/ChaosRecipeEnhancer.UI/Models/UserSettings/WindowSettings/StashTabOverlaySettings.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Models/UserSettings/WindowSettings/StashTabOverlaySettings.cs
@@ -124,6 +124,32 @@ public partial class UserSettings : IUserSettings
         }
     }
 
+    public int StashTabOverlaySessionScreen
+    {
+        get => Settings.Default.StashTabOverlaySessionScreen;
+        set
+        {
+            if (Settings.Default.StashTabOverlaySessionScreen != value)
+            {
+                Settings.Default.StashTabOverlaySessionScreen = value;
+                Save();
+            }
+        }
+    }
+
+    public bool StashTabOverlayModified
+    {
+        get => Settings.Default.StashTabOverlayModified;
+        set
+        {
+            if (Settings.Default.StashTabOverlayModified != value)
+            {
+                Settings.Default.StashTabOverlayModified = value;
+                Save();
+            }
+        }
+    }
+
     public double StashTabOverlayHeight
     {
         get => Settings.Default.StashTabOverlayHeight;

--- a/src/App/ChaosRecipeEnhancer.UI/Properties/Settings.Designer.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ChaosRecipeEnhancer.UI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.11.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -368,30 +368,6 @@ namespace ChaosRecipeEnhancer.UI.Properties {
             }
             set {
                 this["SetTrackerOverlayLeftPosition"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("74")]
-        public double StashTabOverlayTopPosition {
-            get {
-                return ((double)(this["StashTabOverlayTopPosition"]));
-            }
-            set {
-                this["StashTabOverlayTopPosition"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("12")]
-        public double StashTabOverlayLeftPosition {
-            get {
-                return ((double)(this["StashTabOverlayLeftPosition"]));
-            }
-            set {
-                this["StashTabOverlayLeftPosition"] = value;
             }
         }
         
@@ -2298,6 +2274,54 @@ namespace ChaosRecipeEnhancer.UI.Properties {
             }
             set {
                 this["SetTrackerOverlayWindowScale"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double StashTabOverlayTopPosition {
+            get {
+                return ((double)(this["StashTabOverlayTopPosition"]));
+            }
+            set {
+                this["StashTabOverlayTopPosition"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double StashTabOverlayLeftPosition {
+            get {
+                return ((double)(this["StashTabOverlayLeftPosition"]));
+            }
+            set {
+                this["StashTabOverlayLeftPosition"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int StashTabOverlaySessionScreen {
+            get {
+                return ((int)(this["StashTabOverlaySessionScreen"]));
+            }
+            set {
+                this["StashTabOverlaySessionScreen"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool StashTabOverlayModified {
+            get {
+                return ((bool)(this["StashTabOverlayModified"]));
+            }
+            set {
+                this["StashTabOverlayModified"] = value;
             }
         }
     }

--- a/src/App/ChaosRecipeEnhancer.UI/Properties/Settings.settings
+++ b/src/App/ChaosRecipeEnhancer.UI/Properties/Settings.settings
@@ -89,12 +89,6 @@
     <Setting Name="SetTrackerOverlayLeftPosition" Type="System.Double" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="StashTabOverlayTopPosition" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">74</Value>
-    </Setting>
-    <Setting Name="StashTabOverlayLeftPosition" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">12</Value>
-    </Setting>
     <Setting Name="StashTabOverlayHeight" Type="System.Double" Scope="User">
       <Value Profile="(Default)">690</Value>
     </Setting>
@@ -571,6 +565,18 @@
     </Setting>
     <Setting Name="SetTrackerOverlayWindowScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
+    </Setting>
+    <Setting Name="StashTabOverlayTopPosition" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="StashTabOverlayLeftPosition" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="StashTabOverlaySessionScreen" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="StashTabOverlayModified" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/App/ChaosRecipeEnhancer.UI/Windows/StashTabOverlayWindow.xaml.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Windows/StashTabOverlayWindow.xaml.cs
@@ -61,7 +61,7 @@ public partial class StashTabOverlayWindow : Window
             }
             else
             {
-                // Center on primary screen (There is still a little bit of offset from center, but the whole overlay is visible)
+                // Center on primary screen
                 Left = workingArea.Left + (workingArea.Width - Width) / 2;
                 Top = workingArea.Top + (workingArea.Height - Height) / 2;
             }
@@ -123,8 +123,9 @@ public partial class StashTabOverlayWindow : Window
             // Find the index of the current screen
             var screenIndex = Array.IndexOf(screens, currentScreen);
 
-            // Set this specific config to true
+            // Set overlaySessionScreen and modified config to true
             Settings.Default.StashTabOverlayModified = true;
+            Settings.Default.StashTabOverlaySessionScreen = screenIndex;
             // Save the remaining settings
             Settings.Default.Save();
         }

--- a/src/App/ChaosRecipeEnhancer.UI/Windows/StashTabOverlayWindow.xaml.cs
+++ b/src/App/ChaosRecipeEnhancer.UI/Windows/StashTabOverlayWindow.xaml.cs
@@ -30,6 +30,42 @@ public partial class StashTabOverlayWindow : Window
         InitializeComponent();
         DataContext = _model = Ioc.Default.GetService<StashTabOverlayViewModel>();
         MouseHookForStashTabOverlay.MouseAction += HandleMouseAction;
+
+        // Position window based on settings
+        PositionWindowBasedOnSavedSettings();
+    }
+    private void PositionWindowBasedOnSavedSettings()
+    {
+        var settings = Settings.Default;
+        var overlaySessionScreen = settings.StashTabOverlaySessionScreen;
+        var wasOverlaySettingsModified = settings.StashTabOverlayModified;
+        var screen = System.Windows.Forms.Screen.PrimaryScreen;
+
+        if (wasOverlaySettingsModified)
+        {
+            // Retrieve the screen based on the previously saved index
+            screen = System.Windows.Forms.Screen.AllScreens[overlaySessionScreen];
+        }
+        
+
+        if (screen != null)
+        {
+            var workingArea = screen.WorkingArea;
+
+            // Check if the user had modified the overlay settings
+            if (wasOverlaySettingsModified)
+            {
+                // Use the previously saved position
+                Left = settings.StashTabOverlayLeftPosition;
+                Top = settings.StashTabOverlayTopPosition;
+            }
+            else
+            {
+                // Center on primary screen (There is still a little bit of offset from center, but the whole overlay is visible)
+                Left = workingArea.Left + (workingArea.Width - Width) / 2;
+                Top = workingArea.Top + (workingArea.Height - Height) / 2;
+            }
+        }
     }
 
     private void HandleMouseAction(object sender, MouseHookEventArgs e)
@@ -79,13 +115,22 @@ public partial class StashTabOverlayWindow : Window
         if (_model.IsEditing)
         {
             MakeWindowClickThrough(true);
+
+            // Get the current screen the window is on
+            var currentScreen = System.Windows.Forms.Screen.FromHandle(new System.Windows.Interop.WindowInteropHelper(this).Handle);
+            var screens = System.Windows.Forms.Screen.AllScreens;
+
+            // Find the index of the current screen
+            var screenIndex = Array.IndexOf(screens, currentScreen);
+
+            // Set this specific config to true
+            Settings.Default.StashTabOverlayModified = true;
+            // Save the remaining settings
+            Settings.Default.Save();
         }
         else
         {
             MakeWindowClickThrough(false);
-
-            // save the position of the window after it's been moved
-            Settings.Default.Save();
         }
 
         _model.IsEditing = !_model.IsEditing;

--- a/src/App/ChaosRecipeEnhancer.UI/app.manifest
+++ b/src/App/ChaosRecipeEnhancer.UI/app.manifest
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+	
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+      <windowsSettings>
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      </windowsSettings>
+    </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
# This PR fixes issue #660 #664

## Changes to fix #660 
- Introduced new logic to handle stash tab overlay positioning after saving
- Added `bool StashTabOverlayModified` and `int StashTabOverlaySessionScreen` to settings.settings
- Added appropriate getter/setter for the 2 new fields

## Changes to fix #664 :
- Added app.manifest file for setting OS Compatibility and DPI aware configs


## Misc changes:
- Fixed the positioning of `Settings.Default.Save()` (Added clarification, please read in StashTabOverlayWindow.xaml.cs)
- Updated stash tab overlay Top/Left position to 0

##
 [Video after the fix](https://youtu.be/VuyfAoG_Z4A)
There are still some logical coordinates issue related to DPI scaling, but the offset is negligible. You can see it in the attached video where some highlighted areas are 'clicked' even though my cursor is not there.