### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
# 🚀 Pull Request for Graphite Demo

## 📝 Description

Created a simple Express server for the Graphite demo that serves a mock activity feed.

## 🛠️ Changes Made

- ✨ Added a new Express server in `graphite-demo/server.js`
- 🔌 Implemented a `/feed` endpoint that returns sample activity data
- 🧪 Created mock activity feed data with three sample entries

## 🔍 Testing Done

- Verified server starts correctly on port 3000
- Confirmed `/feed` endpoint returns the expected JSON response

## 📦 Dependencies Added or Updated

- Requires Express.js

## 📈 Impact

This change provides a basic backend server for the Graphite demo application, allowing frontend development to proceed with a functional API endpoint.

## ✅ Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] The server runs without issues